### PR TITLE
fix: improve gem lock management

### DIFF
--- a/backend/auth/oauth.py
+++ b/backend/auth/oauth.py
@@ -15,6 +15,7 @@ import uuid
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
 LOCK_EXPIRE_MINUTES = int(os.environ.get("LOCK_EXPIRE_MINUTES", "30"))
 ALGORITHM = os.environ.get("JWT_ALGORITHM", "HS256")
+DATA_DIR = os.environ.get("DATA_DIR")
 
 # Initialize OAuth2 scheme
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
@@ -121,7 +122,20 @@ def clean_expired_locks():
         if lock.expires_at < now
     ]
     for path in expired:
+        # Remove from memory
         del active_locks[path]
+        
+        # Remove lock file
+        try:
+            # Extract star rating and name
+            star_rating = path[0]
+            gem_name = path[2:]  # Skip the "N-" prefix
+            lock_path = os.path.join(DATA_DIR, f"{star_rating}star", f"{gem_name}.lock")
+            if os.path.exists(lock_path):
+                os.remove(lock_path)
+        except (OSError, IndexError):
+            pass
+            
     if expired:
         save_locks()
 

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -30,6 +30,8 @@ export const Modal = ({ isOpen, onClose, onConfirm, title, children, size = '2xl
       size={size}
       scrollBehavior="inside"
       motionPreset="slideInBottom"
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
     >
       <ModalOverlay backdropFilter="blur(4px)" />
       <ModalContent
@@ -48,7 +50,7 @@ export const Modal = ({ isOpen, onClose, onConfirm, title, children, size = '2xl
         >
           {title}
         </ModalHeader>
-        <ModalCloseButton size="lg" />
+        <ModalCloseButton size="lg" onClick={onClose} />
         
         <ModalBody py={6}>
           {children}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -117,12 +117,8 @@ export const acquireLock = async (gemPath: string) => {
 export const releaseLock = async (gemPath: string) => {
   try {
     console.log('Releasing lock...');
-    // Extract star rating and name
-    const [prefix, ...nameParts] = gemPath.split('-');
-    const name = nameParts.join('-');
-    const snakePath = `${prefix}-${toSnakeCase(name)}`;
-    
-    const { data } = await api.delete(`/gems/${snakePath}/lock`);
+    // The gemPath is already in the correct format (e.g. "1-berserkers_eye")
+    const { data } = await api.delete(`/gems/${gemPath}/lock`);
     console.log('Lock released:', data);
     return data;
   } catch (error) {


### PR DESCRIPTION
- Fix lock synchronization between memory and file storage:
  * Update clean_expired_locks to remove lock files when cleaning memory locks
  * Update get_locks to sync in-memory locks with file locks
  * Clean up expired locks in both memory and files

- Fix lock release on modal close:
  * Update Modal to use onClose handler for all close actions
  * Disable automatic closing on overlay click and Esc key
  * Fix TypeScript errors in handleSaveGem and onConfirm handlers

- Simplify lock path handling:
  * Remove unnecessary path manipulation in releaseLock API
  * Use consistent path format across frontend and backend

These changes ensure locks are properly released when:
1. The lock expires
2. The user clicks Cancel or X button
3. The editor modal is closed